### PR TITLE
HCL Bumping aws up to 3.2+

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70.0"
+      version = "~> 3.2"
     }
     random = {
       source  = "hashicorp/random"
-      version = "2.3.0"
+      version = "~> 2.3.0"
     }
     template = {
       source  = "hashicorp/template"
-      version = "2.1.2"
+      version = "~> 2.1.2"
     }
   }
 }


### PR DESCRIPTION
## Overview

- Update versions to support > 3.2 for the `hashicorp/aws` provider

Attempted to run locally, no longer getting version missmatch.

Errors still occur after running, but this should work for 3+.

Closes #17 