### PR TITLE
Update az errors

### DIFF
--- a/modules/nomad_cluster/main.tf
+++ b/modules/nomad_cluster/main.tf
@@ -50,7 +50,6 @@ resource "aws_autoscaling_group" "nomad_servers" {
   wait_for_capacity_timeout = "480s"
   health_check_grace_period = 15
   health_check_type         = "EC2"
-  //vpc_zone_identifier       = data.aws_subnet_ids.default.ids
   tags = [
     {
       key                 = "Name"

--- a/modules/nomad_cluster/main.tf
+++ b/modules/nomad_cluster/main.tf
@@ -50,7 +50,7 @@ resource "aws_autoscaling_group" "nomad_servers" {
   wait_for_capacity_timeout = "480s"
   health_check_grace_period = 15
   health_check_type         = "EC2"
-  vpc_zone_identifier       = data.aws_subnet_ids.default.ids
+  //vpc_zone_identifier       = data.aws_subnet_ids.default.ids
   tags = [
     {
       key                 = "Name"

--- a/modules/nomad_cluster/nomad_clients.tf
+++ b/modules/nomad_cluster/nomad_clients.tf
@@ -9,7 +9,6 @@ resource "aws_autoscaling_group" "nomad_clients" {
   wait_for_capacity_timeout = "480s"
   health_check_grace_period = 15
   health_check_type         = "EC2"
-  vpc_zone_identifier       = data.aws_subnet_ids.default.ids
 
   tags = [
     {

--- a/versions.tf
+++ b/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70.0"
+      version = "~> 3.2"
     }
     random = {
       source  = "hashicorp/random"
-      version = "2.3.0"
+      version = "~> 2.3.0"
     }
     template = {
       source  = "hashicorp/template"
-      version = "2.1.2"
+      version = "~> 2.1.2"
     }
   }
 }


### PR DESCRIPTION
## Summary

This builds on #18 and removes the `vpc_zone_identifier` argument that was deprecated in AWS 2.0 -> AWS 3.0

Verified that errors are removed from TF plan.