### PR TITLE
Update versions, select correct AZs, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,31 +14,22 @@ For more advanced practitioners requiring  a wider variety of configurable optio
 ## How to Use This Module
 
 - Create a Terraform configuration (`main.tf`) that pulls in the module and
-  specifies values of the required variables:
+  specifies values of the required variables. You may use the contents of the
+  [`main.tf`](main.tf) file as your module definition if adding this to your
+  existing infrastructure by changing the source of the module definition.
 
-```hcl
-provider "aws" {
-  region = "<your AWS region>"
-}
+  ```hcl
+  module "nomad_cluster" {
+    source = "hashicorp/nomad-starter/aws"
+    version = "0.2.1"
+    ... <snip>
+  }
+  ```
 
-module "nomad-oss" {
-  source                = "hashicorp/nomad-oss/aws"
-  version               = "<module version>"
-  allowed_inbound_cidrs = ["<list of inbound CIDRs>"]
-  vpc_id                = "<your VPC id>"
-  consul_version        = "<consul version (ex: 1.8.3)>"
-  nomad_version         = "<nomad version (ex: 0.12.3)>"
-  owner                 = "<owner name/tag>"
-  name_prefix           = "<name prefix you would like attached to your environment>"
-  key_name              = "<your SSH key name>"
-  nomad_servers         = 5
-  nomad_clients         = 3
-}
-```
 - `version`: The Nomad AWS [module
-  version](https://registry.terraform.io/modules/hashicorp/nomad-oss/aws/0.2.1)
+  version](https://registry.terraform.io/modules/hashicorp/nomad-starter/aws/latest)
   to pull (e.g. `0.2.1`) during the initialization
-- `allowed_inbound_cidrs`: Allowed CIDR blocks for SSH and API/UI access
+- `allowed_inbound_cidrs`: Allowed CIDR blocks for SSH and API/UI access. You can find your public IP from [whatismyip](https://www.whatsmyip.org/). (e.g. The value for this would look like `"1.1.1.1/32"`)
 - `vpc_id`: ID of the VPC where cloud resources to be provisioned
 - `consul_version`: Desired [Consul
   version](https://releases.hashicorp.com/consul/) to install

--- a/modules/nomad_cluster/main.tf
+++ b/modules/nomad_cluster/main.tf
@@ -7,17 +7,8 @@ data "aws_vpc" "nomad_vpc" {
 }
 
 # data source for subnet ids in VPC
-data "aws_subnet_ids" "default" {
+data "aws_subnet_ids" "available" {
   vpc_id = data.aws_vpc.nomad_vpc.id
-}
-
-# data source for availability zones
-data "aws_availability_zones" "available" {
-  state = "available"
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
 }
 
 # data source for vanilla Ubuntu AWS AMI as base image for cluster
@@ -47,7 +38,7 @@ resource "random_id" "environment_name" {
 resource "aws_autoscaling_group" "nomad_servers" {
   name                      = aws_launch_configuration.nomad_servers.name
   launch_configuration      = aws_launch_configuration.nomad_servers.name
-  availability_zones        = data.aws_availability_zones.available.zone_ids
+  vpc_zone_identifier       = data.aws_subnet_ids.available.ids
   min_size                  = var.nomad_servers
   max_size                  = var.nomad_servers
   desired_capacity          = var.nomad_servers

--- a/modules/nomad_cluster/main.tf
+++ b/modules/nomad_cluster/main.tf
@@ -14,6 +14,10 @@ data "aws_subnet_ids" "default" {
 # data source for availability zones
 data "aws_availability_zones" "available" {
   state = "available"
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 
 # data source for vanilla Ubuntu AWS AMI as base image for cluster
@@ -50,7 +54,6 @@ resource "aws_autoscaling_group" "nomad_servers" {
   wait_for_capacity_timeout = "480s"
   health_check_grace_period = 15
   health_check_type         = "EC2"
-  vpc_zone_identifier       = data.aws_subnet_ids.default.ids
   tags = [
     {
       key                 = "Name"

--- a/modules/nomad_cluster/nomad_clients.tf
+++ b/modules/nomad_cluster/nomad_clients.tf
@@ -2,7 +2,7 @@
 resource "aws_autoscaling_group" "nomad_clients" {
   name                      = aws_launch_configuration.nomad_clients.name
   launch_configuration      = aws_launch_configuration.nomad_clients.name
-  availability_zones        = data.aws_availability_zones.available.zone_ids
+  vpc_zone_identifier       = data.aws_subnet_ids.available.ids
   min_size                  = var.nomad_clients
   max_size                  = var.nomad_clients
   desired_capacity          = var.nomad_clients

--- a/modules/nomad_cluster/nomad_clients.tf
+++ b/modules/nomad_cluster/nomad_clients.tf
@@ -9,7 +9,6 @@ resource "aws_autoscaling_group" "nomad_clients" {
   wait_for_capacity_timeout = "480s"
   health_check_grace_period = 15
   health_check_type         = "EC2"
-  vpc_zone_identifier       = data.aws_subnet_ids.default.ids
 
   tags = [
     {

--- a/versions.tf
+++ b/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.70.0"
+      version = "~> 3.2"
     }
     random = {
       source  = "hashicorp/random"
-      version = "2.3.0"
+      version = "~> 2.3.0"
     }
     template = {
       source  = "hashicorp/template"
-      version = "2.1.2"
+      version = "~> 2.1.2"
     }
   }
 }


### PR DESCRIPTION
## Overview
Closes #17 
This attempts to cover #18 and #20 , without as dirty of a git dependency.

1. Introduced `~>` to the versions. This allows the module flexibility for pinning to major/minor versions of providers.
2. Removed `availability_zones` in favor of a clearer `vpc_zone_identifier`. Currently this looks at all VPC Zones, but with some tagging, could be used to deploy into private subnets.
3. Removed extra code.
4. Updated README to remove the out of date reference to the module, and added references to `main.tf`.

## Testing
I ran this in TFC. I was able to access the hosts with the following configuration:

```hcl
/* module "nomad-oss" {
  source = "git::https://github.com/hashicorp/terraform-aws-nomad-starter.git?ref=jono/availability_zones"
  //version               = "0.2.1"
  allowed_inbound_cidrs = ["x.x.x.x/32"]
  vpc_id                = module.vpc.vpc_id
  consul_version        = "1.9.0"
  nomad_version         = "1.0.4"
  owner                 = "devopsjs-useast2"
  name_prefix           = "hclive"
  key_name      = "devopsjs-useast2"
  nomad_servers = 5
  nomad_clients = 3
}
 */
```

This was iterated on from the original module, and doesn't make references to everything the `main.tf` does, but should still work as a minimal config.